### PR TITLE
Add support for input booleans

### DIFF
--- a/custom_components/mqtt_discoverystream/__init__.py
+++ b/custom_components/mqtt_discoverystream/__init__.py
@@ -6,7 +6,7 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.mqtt import (
-  valid_publish_topic, 
+  valid_publish_topic,
   async_subscribe,
   async_publish,
 )
@@ -114,7 +114,7 @@ async def async_setup(hass, config):
         # Only handle service calls for discoveries we published
         if f"{domain}.{entity}" not in hass.data[DOMAIN][discovery_topic]["conf_published"]:
             return
-        
+
         _LOGGER.debug(f"Message received: topic {msg.topic}; payload: {msg.payload}")
         if element == "set":
             if msg.payload == STATE_ON:
@@ -134,7 +134,7 @@ async def async_setup(hass, config):
                 if ATTR_TRANSITION in payload_json:
                     service_payload[ATTR_TRANSITION] = payload_json[ATTR_TRANSITION]
 
-                if payload_json["state"] == "ON":  
+                if payload_json["state"] == "ON":
                     if ATTR_BRIGHTNESS in payload_json:
                         service_payload[ATTR_BRIGHTNESS] = payload_json[ATTR_BRIGHTNESS]
                     if ATTR_COLOR_TEMP in payload_json:
@@ -185,7 +185,7 @@ async def async_setup(hass, config):
                 encoded_val = json.dumps(val, cls=JSONEncoder)
                 await mqtt_publish(mybase + key, encoded_val, 1, True)
 
-        ent_parts = entity_id.split(".") 
+        ent_parts = entity_id.split(".")
         ent_domain = ent_parts[0]
         ent_id = ent_parts[1]
 
@@ -203,7 +203,7 @@ async def async_setup(hass, config):
                 config["unit_of_meas"] = new_state.attributes["unit_of_measurement"]
             if ("state_class" in new_state.attributes):
                 config["stat_cla"] = new_state.attributes["state_class"]
-                
+
             publish_config = False
             if ent_domain == "sensor" and (has_includes or "device_class" in new_state.attributes):
                 publish_config = True
@@ -213,7 +213,7 @@ async def async_setup(hass, config):
                 config["pl_on"] = STATE_ON
                 publish_config = True
 
-            elif ent_domain == "switch":
+            elif ent_domain == "switch" or ent_domain == "input_boolean":
                 config["pl_off"] = STATE_OFF
                 config["pl_on"] = STATE_ON
                 config["cmd_t"] = f"{mybase}set"
@@ -264,7 +264,7 @@ async def async_setup(hass, config):
                             config["dev"]["cns"] = device.connections
 
                 encoded = json.dumps(config, cls=JSONEncoder)
-                entity_disc_topic = f"{discovery_topic}{entity_id.replace('.', '/')}/config"
+                entity_disc_topic = generate_discovery_topic(entity_id)
                 await mqtt_publish(entity_disc_topic, encoded, 1, True)
                 hass.data[DOMAIN][discovery_topic]["conf_published"].append(entity_id)
 
@@ -285,7 +285,7 @@ async def async_setup(hass, config):
                     payload["color_temp"] = new_state.attributes["color_temp"]
                 if ("effect" in new_state.attributes):
                     payload["effect"] = new_state.attributes["effect"]
-                
+
                 color = {}
                 if ("hs_color" in new_state.attributes and new_state.attributes["hs_color"]):
                     color["h"] = new_state.attributes["hs_color"][0]
@@ -316,10 +316,17 @@ async def async_setup(hass, config):
             payload = new_state.state
             await mqtt_publish(f"{mybase}state", payload, 1, True)
 
+    def generate_discovery_topic(entity_id):
+        entity_parts = entity_id.split('.')
+        if entity_parts[0] == "input_boolean":
+            entity_parts[0] = "switch"
+        return f"{discovery_topic}{'/'.join(entity_parts)}/config"
+
 
     async def my_async_subscribe_mqtt(hass, _):
         await async_subscribe(hass, f"{base_topic}switch/+/set", message_received)
         await async_subscribe(hass, f"{base_topic}light/+/set_light", message_received)
+        await async_subscribe(hass, f"{base_topic}input_boolean/+/set", message_received)
 
     if publish_discovery:
         async_when_setup(hass, "mqtt", my_async_subscribe_mqtt)


### PR DESCRIPTION
input_booleans are a little tricky because MQTT doesn't actually support them (they are HA internal integration). But since they are basically switches, we can masquerade them as MQTT Switches by sending the discovery on that topic.