### PR TITLE
Update __init__.py

### DIFF
--- a/custom_components/mqtt_discoverystream/__init__.py
+++ b/custom_components/mqtt_discoverystream/__init__.py
@@ -59,6 +59,7 @@ CONF_PUBLISH_ATTRIBUTES = "publish_attributes"
 CONF_PUBLISH_TIMESTAMPS = "publish_timestamps"
 CONF_PUBLISH_DISCOVERY = "publish_discovery"
 CONF_UNIQUE_PREFIX = "unique_prefix"
+CONF_SET_OBJECT_ID = "set_object_id"
 
 DOMAIN = "mqtt_discoverystream"
 
@@ -71,6 +72,7 @@ CONFIG_SCHEMA = vol.Schema(
                 vol.Optional(CONF_PUBLISH_ATTRIBUTES, default=False): cv.boolean,
                 vol.Optional(CONF_PUBLISH_TIMESTAMPS, default=False): cv.boolean,
                 vol.Optional(CONF_PUBLISH_DISCOVERY, default=False): cv.boolean,
+                vol.Optional(CONF_SET_OBJECT_ID, default=False): cv.boolean,
                 vol.Optional(CONF_UNIQUE_PREFIX, default="mqtt"): cv.string,
             }
         ),
@@ -90,6 +92,7 @@ async def async_setup(hass, config):
     publish_timestamps = conf.get(CONF_PUBLISH_TIMESTAMPS)
     publish_discovery = conf.get(CONF_PUBLISH_DISCOVERY)
     unique_prefix = conf.get(CONF_UNIQUE_PREFIX)
+    set_object_id = conf.get(CONF_SET_OBJECT_ID)
     if not base_topic.endswith("/"):
         base_topic = f"{base_topic}/"
     if not discovery_topic.endswith("/"):
@@ -198,6 +201,9 @@ async def async_setup(hass, config):
                 "json_attr_t": f"{mybase}attributes",
                 "avty_t": f"{mybase}availability"
             }
+            
+            if set_object_id:
+                config['obj_id'] = f"{unique_prefix}_{ent_id}"
 
             if ("icon" in new_state.attributes):
                 config["ic"]= new_state.attributes["icon"]


### PR DESCRIPTION
Implement set_object_id.
As per [MQTT Naming](https://www.home-assistant.io/integrations/mqtt/#naming-of-mqtt-entities)

> If the object_id option is set, then this will be used to generate the entity_id. If, for example, we have configured a sensor, and we have set object_id to test, then Home Assistant will try to assign sensor.test as entity_id, but if this entity_id already exits it will append it with a suffix to make it unique, for example, sensor.test_2.

**uniq_id** is used only to ensure uniqueness but if the sensor already exists on the master device is it named, as the decumentation mentions, for example **sensor.test_2**. By providing the object as **(unique_prefix)_(entity_name)** the sensor is automatically named to something more intuitive.

![image](https://github.com/koying/mqtt_discoverystream_ha/assets/156668518/11ec014c-c243-4f30-9720-bd328916cc28)
