### PR TITLE
Removed `color_mode`

### DIFF
--- a/custom_components/mqtt_discoverystream/__init__.py
+++ b/custom_components/mqtt_discoverystream/__init__.py
@@ -312,8 +312,6 @@ async def async_setup(hass, config):
                 }
                 if ("brightness" in new_state.attributes):
                     payload["brightness"] = new_state.attributes["brightness"]
-                if ("color_mode" in new_state.attributes):
-                    payload["color_mode"] = new_state.attributes["color_mode"]
                 if ("color_temp" in new_state.attributes):
                     payload["color_temp"] = new_state.attributes["color_temp"]
                 if ("effect" in new_state.attributes):

--- a/custom_components/mqtt_discoverystream/__init__.py
+++ b/custom_components/mqtt_discoverystream/__init__.py
@@ -242,7 +242,6 @@ async def async_setup(hass, config):
                 if supported_features & SUPPORT_EFFECT:
                     config["effect"] = True
                 if "supported_color_modes" in new_state.attributes:
-                    config["color_mode"] = True
                     config["supported_color_modes"] = new_state.attributes["supported_color_modes"]
                     config["brightness"] = True
                 if "effect_list" in new_state.attributes:


### PR DESCRIPTION
Removes the Home Assistant color_mode: true from the discovery payload which was deprecated in home-assistant/core#111676 . Shouldn't cause a breaking change since it was not used anymore:

> The color_mode flag is not used anymore, and should be removed.

Needs to be removed before Home Assistant 2025.3 comes out otherwise it's presence becomes a breaking change.